### PR TITLE
컴포넌트 스캔, 탐색 위치, 필터, 빈 중복

### DIFF
--- a/src/main/java/hello/core/AutoAppConfig.java
+++ b/src/main/java/hello/core/AutoAppConfig.java
@@ -1,0 +1,13 @@
+package hello.core;
+
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
+
+@Configuration
+@ComponentScan(
+        excludeFilters = @ComponentScan.Filter(type = FilterType.ANNOTATION, classes = Configuration.class)
+)
+public class AutoAppConfig {
+
+}

--- a/src/main/java/hello/core/AutoAppConfig.java
+++ b/src/main/java/hello/core/AutoAppConfig.java
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.FilterType;
 
 @Configuration
 @ComponentScan(
+        basePackages = "hello.core",
         excludeFilters = @ComponentScan.Filter(type = FilterType.ANNOTATION, classes = Configuration.class)
 )
 public class AutoAppConfig {

--- a/src/main/java/hello/core/discount/RateDiscountPolicy.java
+++ b/src/main/java/hello/core/discount/RateDiscountPolicy.java
@@ -2,7 +2,9 @@ package hello.core.discount;
 
 import hello.core.member.Grade;
 import hello.core.member.Member;
+import org.springframework.stereotype.Component;
 
+@Component
 public class RateDiscountPolicy implements DiscountPolicy{
 
     private int discountPercent = 10;

--- a/src/main/java/hello/core/member/MemberServiceImpl.java
+++ b/src/main/java/hello/core/member/MemberServiceImpl.java
@@ -1,10 +1,15 @@
 package hello.core.member;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
 public class MemberServiceImpl implements MemberService {
 
     // MemberServiceImpl은 추상화(MemberRepostiory) 에 의존하는 동시에, 구체화(MemoryMemberRepository) 에도 의존한다. -> DIP 를 위반하는 중
     private final MemberRepository memberRepository;
 
+    @Autowired // ac.getBean(MemberRepository.class) -> 타입이 같은 빈을 찾아서 주입
     public MemberServiceImpl(MemberRepository memberRepository) {
         // MemberServiceImpl 입장에서는 생성자를 통해 어떤 구현 객체가 들어올지(주입될지)는 알 수 없다.
         // 생성자를 통해서 어떤 구현 객체를 주입할지는 오직 외부(AppConfig)에서 결정된다.

--- a/src/main/java/hello/core/member/MemoryMemberRepository.java
+++ b/src/main/java/hello/core/member/MemoryMemberRepository.java
@@ -1,8 +1,11 @@
 package hello.core.member;
 
+import org.springframework.stereotype.Component;
+
 import java.util.HashMap;
 import java.util.Map;
 
+@Component
 public class MemoryMemberRepository implements  MemberRepository{
 
     private static Map<Long, Member> store = new HashMap<>();

--- a/src/main/java/hello/core/order/OrderServiceImpl.java
+++ b/src/main/java/hello/core/order/OrderServiceImpl.java
@@ -3,7 +3,10 @@ package hello.core.order;
 import hello.core.discount.DiscountPolicy;
 import hello.core.member.Member;
 import hello.core.member.MemberRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 
+@Component
 public class OrderServiceImpl implements OrderService {
 
     private final MemberRepository memberRepository;
@@ -11,6 +14,7 @@ public class OrderServiceImpl implements OrderService {
 //    private final DiscountPolicy discountPolicy = new FixDiscountPolicy(); // OCP와 DIP를 위반
     private final DiscountPolicy discountPolicy; // 인터페이스에만 의존하도록 코드를 변경
 
+    @Autowired
     public OrderServiceImpl(MemberRepository memberRepository, DiscountPolicy discountPolicy) {
         this.memberRepository = memberRepository;
         this.discountPolicy = discountPolicy;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,1 @@
-
+spring.main.allow-bean-definition-overriding=false

--- a/src/test/java/hello/core/scan/AutoAppConfigTest.java
+++ b/src/test/java/hello/core/scan/AutoAppConfigTest.java
@@ -1,0 +1,19 @@
+package hello.core.scan;
+
+import hello.core.AutoAppConfig;
+import hello.core.member.MemberService;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AutoAppConfigTest {
+
+    @Test
+    void basicScan(){
+        AnnotationConfigApplicationContext ac = new AnnotationConfigApplicationContext(AutoAppConfig.class);
+
+        MemberService memberService = ac.getBean(MemberService.class);
+        assertThat(memberService).isInstanceOf(MemberService.class);
+    }
+}

--- a/src/test/java/hello/core/scan/filter/BeanA.java
+++ b/src/test/java/hello/core/scan/filter/BeanA.java
@@ -1,0 +1,5 @@
+package hello.core.scan.filter;
+
+@MyIncludeComponent
+public class BeanA {
+}

--- a/src/test/java/hello/core/scan/filter/BeanB.java
+++ b/src/test/java/hello/core/scan/filter/BeanB.java
@@ -1,0 +1,5 @@
+package hello.core.scan.filter;
+
+@MyExcludeComponent
+public class BeanB {
+}

--- a/src/test/java/hello/core/scan/filter/ComponentFilterAppConfigTest.java
+++ b/src/test/java/hello/core/scan/filter/ComponentFilterAppConfigTest.java
@@ -1,0 +1,40 @@
+package hello.core.scan.filter;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.springframework.context.annotation.ComponentScan.*;
+
+public class ComponentFilterAppConfigTest {
+
+    @Test
+    void filterScan() {
+        AnnotationConfigApplicationContext ac = new AnnotationConfigApplicationContext(ComponentFilterAppConfig.class);
+        BeanA beanA = ac.getBean("beanA", BeanA.class);
+        assertThat(beanA).isNotNull();
+
+        assertThrows(
+                NoSuchBeanDefinitionException.class,
+                () -> ac.getBean("beanB", BeanB.class)
+        );
+    }
+
+    @Configuration
+    @ComponentScan(
+            includeFilters = @Filter(type = FilterType.ANNOTATION, classes = MyIncludeComponent.class),
+            excludeFilters = {
+                    @Filter(type = FilterType.ANNOTATION, classes = MyExcludeComponent.class)
+//                    ,@Filter(type = FilterType.ASSIGNABLE_TYPE, classes = BeanA.class)
+            }
+    )
+    static class ComponentFilterAppConfig {
+    }
+
+}

--- a/src/test/java/hello/core/scan/filter/MyExcludeComponent.java
+++ b/src/test/java/hello/core/scan/filter/MyExcludeComponent.java
@@ -1,0 +1,9 @@
+package hello.core.scan.filter;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface MyExcludeComponent {
+}

--- a/src/test/java/hello/core/scan/filter/MyIncludeComponent.java
+++ b/src/test/java/hello/core/scan/filter/MyIncludeComponent.java
@@ -1,0 +1,9 @@
+package hello.core.scan.filter;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface MyIncludeComponent {
+}


### PR DESCRIPTION
기존에 사용한 `@Bean` 을 사용하지 않고 `@ComponentScan` 어노테이션을 이용해서 보다 쉽게 스프링 빈을 등록할 수 있는 방법을 도입했다. 이외에도 컴포넌트 스캔에 대한 추가 설정인 탐색 위치와 filter, 빈 중복에 대해 공부했다.

This closes #9 